### PR TITLE
feat: Add viteAsset function to resolve Vite manifest entries

### DIFF
--- a/docs/customisation/viteAsset.md
+++ b/docs/customisation/viteAsset.md
@@ -1,0 +1,36 @@
+---
+title: viteAsset function
+nav_order: 5
+parent: Customisation
+---
+
+# `viteAsset` function
+
+The framework comes with a `viteAsset` function to resolve a Vite manifest entry to its built, hashed asset path, saving you from manually reading and parsing `manifest.json` in every test.
+
+## Example
+
+```ts
+import { viteAsset } from '@liquidlight/playwright-framework';
+
+await page.setContentAndScriptTag(
+	`
+		...
+	`,
+	viteAsset('app/sites/site_package/Resources/Private/JavaScript/core.js')
+);
+```
+
+## More details
+
+By default, `viteAsset` reads the manifest from `html/_assets/vite/.vite/manifest.json` (relative to `process.cwd()`) and returns the built asset path prefixed with `html/_assets/vite/`.
+
+If your project builds Vite assets to a different location, pass a second argument to override the base path:
+
+```ts
+viteAsset('app/sites/site_package/Resources/Private/JavaScript/core.js', 'dist/vite');
+```
+
+This looks for the manifest at `dist/vite/.vite/manifest.json` and returns paths prefixed with `dist/vite/`.
+
+An error is thrown if the requested entry isn't found in the manifest.

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,4 +29,5 @@ export {
 	getEnv,
 	matchHostnameToEnv,
 	matchUrlHostToEnv,
+	viteAsset,
 } from './utils.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,8 @@ import type {
 	ProjectConfig
 } from './types.js';
 import { devices } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Consts
@@ -142,4 +144,16 @@ export function deepMerge<T extends PlainObject>(target: T, ...sources: PlainObj
 // Detect if a variable is an object
 export function isObject(item: any): item is PlainObject {
 	return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+// Resolve a Vite manifest entry to its built asset path
+export function viteAsset(entry: string, basePath: string = 'html/_assets/vite'): string {
+	const manifestPath = path.resolve(process.cwd(), `${basePath}/.vite/manifest.json`);
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+	if (!manifest[entry]) {
+		throw new Error(`viteAsset: no entry found in manifest for "${entry}"`);
+	}
+
+	return `${basePath}/${manifest[entry].file}`;
 }

--- a/tests/vitest/viteAsset.test.ts
+++ b/tests/vitest/viteAsset.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import { viteAsset } from '../../src/utils';
+
+// Mock `fs.readFileSync`
+vi.mock('node:fs')
+
+const mockManifest = {
+	'app/sites/site_package/Resources/Private/JavaScript/core.js': {
+		file: 'assets/core-abc123.js'
+	}
+};
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe('viteAsset', () => {
+	test('should resolve the built asset path using the default base path', () => {
+		(fs.readFileSync as vi.Mock).mockReturnValue(JSON.stringify(mockManifest));
+
+		const result = viteAsset('app/sites/site_package/Resources/Private/JavaScript/core.js');
+
+		expect(fs.readFileSync).toHaveBeenCalledWith(
+			expect.stringContaining('html/_assets/vite/.vite/manifest.json'),
+			'utf8'
+		);
+		expect(result).toBe('html/_assets/vite/assets/core-abc123.js');
+	});
+
+	test('should resolve the built asset path using a custom base path', () => {
+		(fs.readFileSync as vi.Mock).mockReturnValue(JSON.stringify(mockManifest));
+
+		const result = viteAsset('app/sites/site_package/Resources/Private/JavaScript/core.js', 'dist/vite');
+
+		expect(fs.readFileSync).toHaveBeenCalledWith(
+			expect.stringContaining('dist/vite/.vite/manifest.json'),
+			'utf8'
+		);
+		expect(result).toBe('dist/vite/assets/core-abc123.js');
+	});
+
+	test('should throw an error if the entry is missing from the manifest', () => {
+		(fs.readFileSync as vi.Mock).mockReturnValue(JSON.stringify(mockManifest));
+
+		expect(() => viteAsset('missing/entry.js')).toThrow('viteAsset: no entry found in manifest for "missing/entry.js"');
+	});
+});


### PR DESCRIPTION
Closes #47. Saves tests from manually reading and parsing the Vite
manifest.json to build a script tag path, and exposes it via the
package's main entry point.